### PR TITLE
Add `dependent: :destroy` to models

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
 # Trex Back-End
-<<<<<<< HEAD
-=======
 
 ## Table of Contents
 - [Setup](#setup)
@@ -38,7 +36,6 @@
     - [Create Notification](#create-notification)
     - [Update Notification](#update-notification)
     - [Remove Notification](#remove-notification)
->>>>>>> 6dd14b19d773a80c387842f27ac7602d566a49cf
 
 ## Setup
 
@@ -65,7 +62,7 @@ To setup the database on your local machine run the following commands in order:
 
 ## GraphQL Queries
 
-Query the database for resources and data that <i> belongs_to </i>  a resource.  Below are example queries, the request can be edited to return all attributes or only the attributes that you need from a given resource .  
+Query the database for resources and data that <i> belongs_to </i> a resource. Below are example queries, the request can be edited to return all attributes or only the attributes that you need from a given resource.  
 
 ### Country Information
 
@@ -389,14 +386,8 @@ Query the database for resources and data that <i> belongs_to </i>  a resource. 
 }
 ```
 
-
-
 ### Response
-<<<<<<< HEAD
-```json 
-=======
 ```json
->>>>>>> 6dd14b19d773a80c387842f27ac7602d566a49cf
 {
   "data": {
     "travelAdvisories": [
@@ -520,11 +511,6 @@ Query the database for resources and data that <i> belongs_to </i>  a resource. 
         "message": "Kuwait has a current risk level of 2.2 (out of 5). We advise: Travelling Kuwait is (relatively) safe.",
         "score": 2.2
       },
-<<<<<<< HEAD
-      
-=======
-
->>>>>>> 6dd14b19d773a80c387842f27ac7602d566a49cf
       {
         "id": "237",
         "name": "Zambia",
@@ -1086,9 +1072,8 @@ Returns all users in the database
 }
 ```
 
-
 ### User and User's Trips
-Returns a single User(determined by id) and the user's associated trips
+Returns a single User (determined by id) and the user's associated trips
 
 #### Request:
 
@@ -1112,38 +1097,23 @@ Returns a single User(determined by id) and the user's associated trips
 {
   "data": {
     "user": {
-      "name": "Penelope Conn",
-      "email": "cordelia_mraz@smithambeier.net",
+      "name": "Trudie Deckow",
+      "email": "marylouise@robel.org",
       "trips": [
         {
-          "name": "Honduras",
-          "startDate": "2018-10-23",
-          "endDate": "2020-04-21"
+          "name": "Argentina",
+          "startDate": "2019-03-07",
+          "endDate": "2020-09-26"
         },
         {
-          "name": "Indonesia",
-          "startDate": "2019-03-24",
-          "endDate": "2020-01-20"
+          "name": "Kiribati",
+          "startDate": "2019-07-14",
+          "endDate": "2020-06-30"
         },
         {
-          "name": "Mayotte",
-          "startDate": "2019-01-01",
-          "endDate": "2019-10-24"
-        },
-        {
-          "name": "Sierra Leone",
-          "startDate": "2019-08-10",
-          "endDate": "2020-05-15"
-        },
-        {
-          "name": "Colombia",
-          "startDate": "2019-07-04",
-          "endDate": "2020-07-11"
-        },
-        {
-          "name": "Malaysia",
-          "startDate": "2019-03-22",
-          "endDate": "2019-12-24"
+          "name": "Costa Rica",
+          "startDate": "2019-06-27",
+          "endDate": "2019-12-07"
         }
       ]
     }
@@ -1151,12 +1121,8 @@ Returns a single User(determined by id) and the user's associated trips
 }
 ```
 
-<<<<<<< HEAD
-### Trip & Trip's Legs
-=======
 ### Trip and Trip's Legs
->>>>>>> 6dd14b19d773a80c387842f27ac7602d566a49cf
-Returns a single trip(by id passed in), and the associated legs
+Returns a single trip (by id passed in), and the associated legs
 
 #### Request
 
@@ -1168,9 +1134,11 @@ Returns a single trip(by id passed in), and the associated legs
     endDate
   }
   legs {
-    name
     startDate
+    startLocation
     endDate
+    endLocation
+    tripId
   }
 }
 ```
@@ -1181,66 +1149,87 @@ Returns a single trip(by id passed in), and the associated legs
 {
   "data": {
     "trip": {
-      "name": "Lesotho",
-      "startDate": "2019-05-29",
-      "endDate": "2019-12-11"
+      "name": "Argentina",
+      "startDate": "2019-03-07",
+      "endDate": "2020-09-26"
     },
     "legs": [
       {
-        "name": "Malta",
-        "startDate": "2019-06-27",
-        "endDate": "2020-09-09"
+        "startDate": "2019-07-31",
+        "startLocation": "Bernierland",
+        "endDate": "2019-11-04",
+        "endLocation": "South Mindaton",
+        "tripId": 1
       },
       {
-        "name": "Guyana",
-        "startDate": "2019-10-19",
-        "endDate": "2020-08-11"
+        "startDate": "2019-06-16",
+        "startLocation": "Medhursttown",
+        "endDate": "2020-05-30",
+        "endLocation": "Rudolphchester",
+        "tripId": 1
       },
       {
-        "name": "Grenada",
-        "startDate": "2019-01-12",
-        "endDate": "2020-04-23"
+        "startDate": "2019-05-18",
+        "startLocation": "Dulceberg",
+        "endDate": "2020-05-23",
+        "endLocation": "Port Guy",
+        "tripId": 1
       },
       {
-        "name": "French Guiana",
-        "startDate": "2019-09-28",
-        "endDate": "2019-12-10"
+        "startDate": "2019-07-31",
+        "startLocation": "Lake Ulysses",
+        "endDate": "2020-06-28",
+        "endLocation": "Fritzchester",
+        "tripId": 1
       },
       {
-        "name": "Burundi",
-        "startDate": "2019-04-13",
-        "endDate": "2019-12-31"
+        "startDate": "2018-11-23",
+        "startLocation": "Rainabury",
+        "endDate": "2020-07-08",
+        "endLocation": "Watersfurt",
+        "tripId": 2
       },
       {
-        "name": "Czech Republic",
-        "startDate": "2019-01-01",
-        "endDate": "2020-03-10"
+        "startDate": "2019-07-26",
+        "startLocation": "Danieltown",
+        "endDate": "2019-11-09",
+        "endLocation": "South Paulina",
+        "tripId": 2
       },
       {
-        "name": "Comoros",
-        "startDate": "2018-12-16",
-        "endDate": "2020-02-27"
+        "startDate": "2019-08-21",
+        "startLocation": "South Rashadport",
+        "endDate": "2020-02-24",
+        "endLocation": "Arthurtown",
+        "tripId": 2
       },
       {
-        "name": "Nigeria",
-        "startDate": "2019-07-15",
-        "endDate": "2020-06-29"
+        "startDate": "2019-04-05",
+        "startLocation": "Lake Brigitteview",
+        "endDate": "2020-04-11",
+        "endLocation": "New Maud",
+        "tripId": 3
       },
       {
-        "name": "Saint Kitts and Nevis",
-        "startDate": "2019-07-16",
-        "endDate": "2020-02-22"
+        "startDate": "2019-01-10",
+        "startLocation": "Tajuanamouth",
+        "endDate": "2020-07-30",
+        "endLocation": "Kesslertown",
+        "tripId": 3
+      },
+      {
+        "startDate": "10/30/19",
+        "startLocation": "New York",
+        "endDate": "11/12/19",
+        "endLocation": "Japan",
+        "tripId": 1
       }
     ]
   }
 }
 ```
 
-<<<<<<< HEAD
-### Leg & Leg Destinations
-=======
 ### Leg and Leg Destinations
->>>>>>> 6dd14b19d773a80c387842f27ac7602d566a49cf
 Returns single leg based on the ID passed in, and the associated destinations
 
 #### Request
@@ -1249,8 +1238,10 @@ Returns single leg based on the ID passed in, and the associated destinations
 {
   leg(id: 1) {
     destinations {
-      name
-
+      id
+      city
+      country
+      legId
     }
   }
 }
@@ -1264,13 +1255,22 @@ Returns single leg based on the ID passed in, and the associated destinations
     "leg": {
       "destinations": [
         {
-          "name": "North Sharieton"
+          "id": "1",
+          "city": "South Tawanna",
+          "country": "West Jodyshire",
+          "legId": 1
         },
         {
-          "name": "Hannahmouth"
+          "id": "2",
+          "city": "South Jesse",
+          "country": "East Jefferey",
+          "legId": 1
         },
         {
-          "name": "West Carlo"
+          "id": "3",
+          "city": "Kyleport",
+          "country": "South Winter",
+          "legId": 1
         }
       ]
     }
@@ -1278,11 +1278,7 @@ Returns single leg based on the ID passed in, and the associated destinations
 }
 ```
 
-<<<<<<< HEAD
-### User & User's Notifications
-=======
 ### User and User's Notifications
->>>>>>> 6dd14b19d773a80c387842f27ac7602d566a49cf
 Returns all the notifications for a single user by passing in the user's ID
 
 #### Request
@@ -1309,8 +1305,8 @@ Returns all the notifications for a single user by passing in the user's ID
   "data": {
     "user": {
       "id": "1",
-      "name": "Michal Bauch",
-      "email": "lecia@schamberger.biz"
+      "name": "Trudie Deckow",
+      "email": "marylouise@robel.org"
     },
     "notifications": [
       {
@@ -1327,17 +1323,33 @@ Returns all the notifications for a single user by passing in the user's ID
         "id": "3",
         "active": true,
         "userId": 1
+      },
+      {
+        "id": "4",
+        "active": true,
+        "userId": 2
+      },
+      {
+        "id": "5",
+        "active": true,
+        "userId": 2
+      },
+      {
+        "id": "6",
+        "active": false,
+        "userId": 3
+      },
+      {
+        "id": "7",
+        "active": false,
+        "userId": 3
       }
     ]
   }
 }
 ```
 
-<<<<<<< HEAD
-### Legs & Leg Transportations
-=======
 ### Leg and Leg Transportations
->>>>>>> 6dd14b19d773a80c387842f27ac7602d566a49cf
 Returns single leg based on the ID passed in, and associated transportations
 
 #### Request
@@ -1346,9 +1358,10 @@ Returns single leg based on the ID passed in, and associated transportations
 {
   leg(id: 1) {
     id
-    name
     startDate
+    startLocation
     endDate
+    endLocation
     tripId
   }
   transportations {
@@ -1369,55 +1382,72 @@ Returns single leg based on the ID passed in, and associated transportations
   "data": {
     "leg": {
       "id": "1",
-      "name": "Tuvalu",
-      "startDate": "2019-07-15",
-      "endDate": "2019-11-18",
+      "startDate": "2019-07-31",
+      "startLocation": "Bernierland",
+      "endDate": "2019-11-04",
+      "endLocation": "South Mindaton",
       "tripId": 1
     },
     "transportations": [
       {
         "id": "1",
         "mode": "flight",
-        "departureTime": "2020-09-19 03:56:51 -0600",
-        "departureCity": "Sonfurt",
-        "arrivalTime": "2019-07-20 06:53:13 -0600",
-        "arrivalCity": "South Yvone"
+        "departureTime": "2020-03-19 19:07:22 -0600",
+        "departureCity": "Kirbyhaven",
+        "arrivalTime": "2018-11-20 23:04:46 -0700",
+        "arrivalCity": "Handview"
       },
       {
         "id": "2",
         "mode": "flight",
-        "departureTime": "2020-01-13 16:01:26 -0700",
-        "departureCity": "Conradville",
-        "arrivalTime": "2019-04-02 04:08:33 -0600",
-        "arrivalCity": "Lake Felix"
+        "departureTime": "2020-06-30 00:02:21 -0600",
+        "departureCity": "Lake Cole",
+        "arrivalTime": "2019-10-01 07:57:27 -0600",
+        "arrivalCity": "Port Twila"
       },
       {
         "id": "3",
         "mode": "flight",
-        "departureTime": "2019-12-14 23:59:54 -0700",
-        "departureCity": "New Buster",
-        "arrivalTime": "2019-01-17 04:08:12 -0700",
-        "arrivalCity": "Port Billfurt"
+        "departureTime": "2020-02-27 02:35:27 -0700",
+        "departureCity": "East Kera",
+        "arrivalTime": "2019-03-22 11:02:09 -0600",
+        "arrivalCity": "East Charliechester"
+      },
+      {
+        "id": "4",
+        "mode": "flight",
+        "departureTime": "2020-10-11 15:25:01 -0600",
+        "departureCity": "Bartolettibury",
+        "arrivalTime": "2019-02-24 14:52:45 -0700",
+        "arrivalCity": "North Juana"
+      },
+      {
+        "id": "5",
+        "mode": "flight",
+        "departureTime": "2020-08-28 06:59:01 -0600",
+        "departureCity": "South Bryonstad",
+        "arrivalTime": "2019-02-23 12:16:10 -0700",
+        "arrivalCity": "South Chanellview"
       }
     ]
   }
 }
 ```
 
-<<<<<<< HEAD
-### Destination & Destination Lodgings
-=======
 ### Destination and Destination Lodgings
->>>>>>> 6dd14b19d773a80c387842f27ac7602d566a49cf
 Returns single destination based on the ID passed in, and the associated lodgings
 
 #### Request
 
 ```graphql
 {
-  leg(id: 1) {
-    destinations {
+  destination(id: 1) {
+    lodgings {
       name
+    	arrivalDate
+    	departureDate
+    	city
+    	destinationId
     }
   }
 }
@@ -1428,16 +1458,28 @@ Returns single destination based on the ID passed in, and the associated lodging
 ```json
 {
   "data": {
-    "leg": {
-      "destinations": [
+    "destination": {
+      "lodgings": [
         {
-          "name": "North Sharieton"
+          "name": "Dietrich-Satterfield",
+          "arrivalDate": "2018-12-24",
+          "departureDate": "2020-04-16",
+          "city": "Cassaundraborough",
+          "destinationId": 1
         },
         {
-          "name": "Hannahmouth"
+          "name": "Wisoky, Stiedemann and Hackett",
+          "arrivalDate": "2019-04-18",
+          "departureDate": "2020-03-06",
+          "city": "Lake Cherrystad",
+          "destinationId": 1
         },
         {
-          "name": "West Carlo"
+          "name": "Nienow LLC",
+          "arrivalDate": "2019-07-29",
+          "departureDate": "2020-04-16",
+          "city": "Gerryshire",
+          "destinationId": 1
         }
       ]
     }

--- a/app/models/country_information.rb
+++ b/app/models/country_information.rb
@@ -1,3 +1,2 @@
 class CountryInformation < ApplicationRecord
-  
 end

--- a/app/models/destination.rb
+++ b/app/models/destination.rb
@@ -1,6 +1,6 @@
 class Destination < ApplicationRecord
   belongs_to :leg
-  has_many :lodgings
+  has_many :lodgings, dependent: :destroy
   has_many :pois
   has_one :currency_information
   geocoded_by :city

--- a/app/models/leg.rb
+++ b/app/models/leg.rb
@@ -1,5 +1,5 @@
 class Leg < ApplicationRecord
   belongs_to :trip
   has_many :destinations, dependent: :destroy
-  has_many :transportations
+  has_many :transportations, dependent: :destroy
 end

--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -1,5 +1,4 @@
 class Trip < ApplicationRecord
   belongs_to :user
   has_many :legs, dependent: :destroy
-
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,15 +1,15 @@
 class User < ApplicationRecord
   has_many :trips, dependent: :destroy
-  has_many :notifications
+  has_many :notifications, dependent: :destroy
+
   validates_presence_of :name
   validates :email, presence: true, uniqueness: true
 
   enum role: ['wanderer', 'follower', 'admin']
 
-  has_many :friendships
+  has_many :friendships, dependent: :destroy
   has_many :friends, through: :friendships
-  has_many :trips
 
-  has_many :inverse_friendships, class_name: 'Friendship', foreign_key: 'friend_id'
-  has_many :inverse_friends, through: :inverse_friendships, source: :user
+  has_many :inverse_friendships, class_name: 'Friendship', foreign_key: 'friend_id', dependent: :destroy
+  has_many :inverse_friends, through: :inverse_friendships, source: :user, dependent: :destroy
 end


### PR DESCRIPTION
## Pull Request Review Template

- [ ] Wrote Tests
- [X] Implemented
- [X] Reviewed

### Necessary checkmarks:
- [ ] All Tests are Passing
- [X] The code will run locally

### Type of change
- [ ] New feature
- [X] Bug Fix

### Implements/Fixes:
Fix: We were unable to delete the first Trip in the database and the associated legs with that trip. After adding `dependent: :destroy` to all of our `has_many` associations, the issue was resolved.

### Description of Changes:
- Add `dependent: :destroy` to transportations association in Leg model
- Add `dependent: :destroy` to lodgings association in Destination model
- Add `dependent: :destroy` to `has_many` associations in User model
- Delete whitespace on line 2
- Delete whitespace on line 4
- Update README

closes#

### Check the correct boxes
- [X] This broke nothing
- [ ] This broke some stuff
- [ ] This broke everything

### Testing Changes
- COVERAGE SCORE:
- [ ] New Tests have been added
- [X] No Tests have been changed
- [ ] Some Tests have been changed
- [ ] All of the Tests have been changed (Please describe what in the world happened)

### Checklist:
- [X] My code has no unused/commented out code
- [X] I have reviewed my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have fully tested my code